### PR TITLE
fix for error on ios

### DIFF
--- a/lib/subscribe/val.js
+++ b/lib/subscribe/val.js
@@ -5,7 +5,7 @@ const UPDATE = 'update'
 const REMOVE = 'remove'
 const SWITCH = 'switch'
 
-exports.update = function update (target, travelTarget, subs, update, tree, stamp) {
+exports.update = function up (target, travelTarget, subs, update, tree, stamp) {
   if ('val' in subs && subs.val === true) {
     update(target, UPDATE, stamp, subs, tree)
   }


### PR DESCRIPTION
when running `adm-native-ios` it throws this error: ` SyntaxError: Cannot declare a parameter named 'update' as it shadows the name of a strict mode function.` when I rename it back to `up` it works again.